### PR TITLE
Dont deserialize

### DIFF
--- a/app/models/dj_mon/dj_report.rb
+++ b/app/models/dj_mon/dj_report.rb
@@ -11,7 +11,7 @@ module DjMon
     def as_json(options={})
       {
         :id => delayed_job.id.to_s,
-        :payload => payload(delayed_job),
+        :payload => delayed_job.handler,
         :priority => delayed_job.priority,
         :attempts => delayed_job.attempts,
         :queue => delayed_job.queue || "global",
@@ -22,10 +22,6 @@ module DjMon
         :created_at => l_datetime(delayed_job.created_at),
         :failed => delayed_job.failed_at.present?
       }
-    end
-
-    def payload job
-      job.payload_object.respond_to?(:object) ? job.payload_object.object.to_yaml : job.payload_object.to_yaml
     end
 
     class << self


### PR DESCRIPTION
If failed jobs refer removed classes, the whole job list fails to display due to deserialization error.
